### PR TITLE
feat(@142vip/utils): 新增`createSemver`创建实例，支持`originImportSemVer`原生导入的`semver`对象

### DIFF
--- a/packages/utils/src/pkgs/semver.ts
+++ b/packages/utils/src/pkgs/semver.ts
@@ -1,15 +1,24 @@
-import type { ReleaseType } from 'semver'
-import {
+import type { RangeOptions, ReleaseType } from 'semver'
+import originImportSemVer, {
   clean,
   compare,
   eq,
   gt,
   inc,
   lt,
+  parse,
   prerelease,
   satisfies,
+  SemVer,
   valid,
 } from 'semver'
+
+/**
+ * 支持原生创建Semver实例
+ */
+function createSemver(version: string | SemVer, optionsOrLoose?: boolean | RangeOptions): SemVer {
+  return new SemVer(version, optionsOrLoose)
+}
 
 /**
  * 参考：https://www.npmjs.com/package/semver
@@ -22,8 +31,11 @@ export const VipSemver = {
   lt,
   eq,
   inc,
+  parse,
   compare,
   prerelease,
+  createSemver,
+  originImportSemVer,
 }
 
 export type VipSemverReleaseType = ReleaseType


### PR DESCRIPTION
…`semver`对象